### PR TITLE
Checks to ensure the message is same size or less than one time pad length

### DIFF
--- a/lib/number_station/cli.rb
+++ b/lib/number_station/cli.rb
@@ -189,5 +189,14 @@ module NumberStation
     end
 
 
+    # version
+    desc "version", "Print the version of the Number Stations gem."
+    long_desc <<-VERSION_LONG_DESC
+    Prints the version of the Number Stations gem.
+    VERSION_LONG_DESC
+    def version()
+      NumberStation::ConfigReader.read_config()
+      NumberStation.log.debug "Version: #{NumberStation::VERSION}"
+    end
   end
 end

--- a/lib/number_station/decrypt_message.rb
+++ b/lib/number_station/decrypt_message.rb
@@ -34,6 +34,10 @@ module NumberStation
     end
 
     crypto_hex_str = pad_data["pads"][pad_num]["key"]
+    if message.size > crypto_hex_str.size
+      NumberStation.log.error "Error: The message length is greater than pad length. Unable to continue decryption."
+      exit
+    end
     NumberStation.log.debug "message length less than pad length: #{message.size <= crypto_hex_str.size}"
 
     crypto_byte_array = crypto_hex_str.scan(/.{1}/).each_slice(2).map { |f, l| (Integer(f,16) << 4) + Integer(l,16) }

--- a/lib/number_station/encrypt_message.rb
+++ b/lib/number_station/encrypt_message.rb
@@ -33,8 +33,15 @@ module NumberStation
       raise e
     end
 
+    crypto_hex_str = pad_data["pads"][pad_num]["key"]
+
+    if message.size > crypto_hex_str.size
+      NumberStation.log.error "Exception: message length is larger than pad length. Break the message into smaller parts."
+      exit
+    end
+    NumberStation.log.debug "message length less than pad length"
+
     unless pad_data["pads"][pad_num]["consumed"]
-      crypto_hex_str = pad_data["pads"][pad_num]["key"]
       NumberStation.log.debug "Marking key as consumed"
       pad_data["pads"][pad_num]["epoch_date"] = Time.now.to_i
       pad_data["pads"][pad_num]["consumed"] = true
@@ -47,7 +54,6 @@ module NumberStation
        exit
     end
 
-    NumberStation.log.debug "message length less than pad length: #{message.size <= crypto_hex_str.size}"
     crypto_byte_array = crypto_hex_str.scan(/.{1}/).each_slice(2).map { |f, l| (Integer(f,16) << 4) + Integer(l,16) }
 
     encrypted_byte_array = []

--- a/lib/number_station/version.rb
+++ b/lib/number_station/version.rb
@@ -20,5 +20,5 @@
 =end
 
 module NumberStation
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
# What
Check to ensure that the message to be encrypted is same size or less than the one time path length.


# Why
Can't encrypt it if its larger



# How
N/A


# Verification Steps
- Create message 501 characters long
- Try to encrypt it: 
```number_station encrypt_message message_bigger_than_max_length.txt --numpad 4 --padpath pads/one_time_pad_99894.json
D, [2019-11-11T19:15:29.307675 #5157] DEBUG -- : Reading in config file: /home/dkirwan/number_station/conf.json
D, [2019-11-11T19:15:29.307708 #5157] DEBUG -- : NumberStation::ConfigReader#read_config
D, [2019-11-11T19:15:29.307743 #5157] DEBUG -- : encrypt_message
D, [2019-11-11T19:15:29.307784 #5157] DEBUG -- : numpad: 4
D, [2019-11-11T19:15:29.307798 #5157] DEBUG -- : padpath: pads/one_time_pad_99894.json
D, [2019-11-11T19:15:29.307813 #5157] DEBUG -- : message length: 502
E, [2019-11-11T19:15:29.309007 #5157] ERROR -- : Exception: message length is larger than pad length. Break the message into smaller parts.
```


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
